### PR TITLE
Allow gora to start via plain http

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,8 @@ jobs:
       run: make test
     - name: Build
       run: make build
+    - name: Smoke
+      run: |
+            make run &
+            sleep 5
+            make smoke-test

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ server.key:
 run: server.crt server.key
 	@echo "Running on port 4443"
 	SSL=true SERVER_KEY=server.key SERVER_CRT=server.crt PORT=4443 go run ./main.go
+
+smoke-test: server.crt server.key
+	ADDRESS=localhost SSL=true SERVER_KEY=server.key SERVER_CRT=server.crt PORT=4443 ./scripts/smoke.sh

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ server.key:
 
 run: server.crt server.key
 	@echo "Running on port 4443"
-	SERVER_KEY=server.key SERVER_CRT=server.crt PORT=4443 go run ./main.go
+	SSL=true SERVER_KEY=server.key SERVER_CRT=server.crt PORT=4443 go run ./main.go

--- a/scripts/gen-keys
+++ b/scripts/gen-keys
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ADDRESS="${ADDRESS:-localhost}"
+
 openssl genrsa -out server.key 2048
 
-openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650 -subj "/C=EU/ST=Germany/L=Franconia/O=Quarks/CN=${ADDRESS}"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Smoke tests for GORA. Meant to be run as a bosh errand
+# Requires: curl
+
+ADDRESS=${ADDRESS:-localhost}
+SERVER_KEY=${SERVER_KEY:-}
+SERVER_CRT=${SERVER_CRT:-}
+PORT=${PORT:-4443}
+SSL=${SSL:-false}
+
+if [[ "$SSL" == "true" ]]; then
+ HOST="--cacert ${SERVER_CRT} -sS https://${ADDRESS}:${PORT}"
+else
+ HOST="-sS http://${ADDRESS}:${PORT}"
+fi
+
+echo
+echo "Running GORA smoke tests"
+echo
+echo "========================="
+set -eo pipefail
+
+if curl $HOST | grep -q "SSL=${SSL}"; then
+    echo "Can check SSL is present in env var"
+else
+    echo "SSL not present in env var"
+    exit 1
+fi
+
+if curl -d "echo FOO;exit 1" $HOST | grep -q "error: FOO"; then
+    echo "Correctly returns message on failure"
+else
+    echo "didn't failed as expected"
+    exit 1
+fi
+
+if curl -d "echo FOO;exit 0" $HOST | grep -q "OK"; then
+    echo "Correctly returns OK when exits successfully"
+else
+    echo "didn't succeeded as expected"
+    exit 1
+fi


### PR DESCRIPTION
There are cases (https://github.com/cloudfoundry-incubator/quarks-operator/blob/ed1973a978f8a2fa87085377e478a5fa9f7edf04/testing/boshmanifest/manifests.go#L69) where we don't need to require SSL connections, otherwise we have to supply certificates. Test cases would become more large and execute code out of the scope for the test.

[#172079287](https://www.pivotaltracker.com/story/show/172079287)